### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Coverage Status](https://coveralls.io/repos/creimers/cmsplugin_seocheck/badge.svg?branch=develop)](https://coveralls.io/r/creimers/cmsplugin_seocheck?branch=develop)
 [![Code Climate](https://codeclimate.com/github/creimers/cmsplugin_seocheck/badges/gpa.svg)](https://codeclimate.com/github/creimers/cmsplugin_seocheck)
 [![Requirements Status](https://requires.io/github/creimers/cmsplugin_seocheck/requirements.svg?branch=master)](https://requires.io/github/creimers/cmsplugin_seocheck/requirements/?branch=master)
-[![Latest Version](https://img.shields.io/pypi/v/cmsplugin_seocheck.svg
-[![Supported Python versions](https://img.shields.io/pypi/pyversions/cmsplugin_seocheck.svg
-[![Development Status](https://img.shields.io/pypi/status/cmsplugin_seocheck.svg
+[![Latest Version](https://img.shields.io/pypi/v/cmsplugin_seocheck.svg)](https://pypi.python.org/pypi/cmsplugin-seocheck/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/cmsplugin_seocheck.svg)](https://pypi.python.org/pypi/cmsplugin-seocheck/)
+[![Development Status](https://img.shields.io/pypi/status/cmsplugin_seocheck.svg)](https://pypi.python.org/pypi/cmsplugin_seocheck/)
 # djangocms SEO check plugin
 
 A djangocms plugin to check SEO aspects of your page. Inspired by [yoast](https://yoast.com/) for wordpress.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Coverage Status](https://coveralls.io/repos/creimers/cmsplugin_seocheck/badge.svg?branch=develop)](https://coveralls.io/r/creimers/cmsplugin_seocheck?branch=develop)
 [![Code Climate](https://codeclimate.com/github/creimers/cmsplugin_seocheck/badges/gpa.svg)](https://codeclimate.com/github/creimers/cmsplugin_seocheck)
 [![Requirements Status](https://requires.io/github/creimers/cmsplugin_seocheck/requirements.svg?branch=master)](https://requires.io/github/creimers/cmsplugin_seocheck/requirements/?branch=master)
-[![Latest Version](https://pypip.in/version/cmsplugin_seocheck/badge.svg)](https://pypi.python.org/pypi/cmsplugin-seocheck/)
-[![Supported Python versions](https://pypip.in/py_versions/cmsplugin_seocheck/badge.svg)](https://pypi.python.org/pypi/cmsplugin-seocheck/)
-[![Development Status](https://pypip.in/status/cmsplugin_seocheck/badge.svg)](https://pypi.python.org/pypi/cmsplugin_seocheck/)
+[![Latest Version](https://img.shields.io/pypi/v/cmsplugin_seocheck.svg
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/cmsplugin_seocheck.svg
+[![Development Status](https://img.shields.io/pypi/status/cmsplugin_seocheck.svg
 # djangocms SEO check plugin
 
 A djangocms plugin to check SEO aspects of your page. Inspired by [yoast](https://yoast.com/) for wordpress.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cmsplugin-seocheck))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cmsplugin-seocheck`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.